### PR TITLE
fix(ci): action release now it's ready to run

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,9 +1,3 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-
 ## [1.1.1](https://github.com/immobiliare/inca/compare/1.1.0...1.1.1) (2023-12-19)
 
 ### Bug Fixes

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,11 @@
 
 Simply run `go test -v ./...`.
 
+## Commit guidelines
+
+Please see the [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 ## Contributors
 
 * [`@streambinder`](https://github.com/streambinder)
-* [`@fabfurnari`](https://github.com/fabfurnari)
+* [`@tgragnato`](https://github.com/tgragnato)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,19 +16,21 @@ jobs:
         id: changelog
         uses: TriPSs/conventional-changelog-action@v5
         with:
+          preset: conventionalcommits
           github-token: ${{ secrets.GH_SRE_TOKEN }}
+          git-user-name: ${{ github.actor }}
+          git-user-email: ${{ github.actor }}@users.noreply.github.com
           tag-prefix: ''
-          release-count: 0
+          input-file: '.github/CHANGELOG.md'
+          output-file: '.github/CHANGELOG.md'
+          release-count: 10000
           skip-on-empty: false
           skip-version-file: true
-          output-file: '.github/CHANGELOG.md'
 
       - name: Create Release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_SRE_TOKEN }}
         with:
           tag_name: ${{ steps.changelog.outputs.tag }}
-          release_name: ${{ steps.changelog.outputs.tag }}
           body: ${{ steps.changelog.outputs.clean_changelog }}
+          token: ${{ secrets.GH_SRE_TOKEN }}


### PR DESCRIPTION
I tried this behavior in other my personal repository and I think that this is a correct configuration.

How it works: after this merge e in the feature when you would generate a new release go to tab actions, select "Create release" workflow and click on "Run workflow".

 The workflow will do:
 - choose new bump version (from conventional commits)
 - update the file changelog
 - commit file changelog updated
 - push new tag and release tag

@tgragnato would you like to try after the merge? 😄 