### PR TITLE
fix(test): switch the path for unit testing to an absolute one

### DIFF
--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -14,7 +14,7 @@ const (
 	testingConfig     = `templates_path: ../server/views
 storage:
     type: fs
-    path: ./
+    path: /tmp
 `
 )
 

--- a/server/inca_test.go
+++ b/server/inca_test.go
@@ -18,7 +18,7 @@ const (
 	testingConfig      = `bind: :65535
 storage:
     type: fs
-    path: ./
+    path: /tmp
 providers:
     - type: local
       crt: ` + testingCACrtPath + `


### PR DESCRIPTION
Unit testing works in a containerised environment because the relative path for the workdir is set by the environment to `/tmp`.

Unit testing is currently broken in the IDE because the relative path for the workdir is the basedir of the file you are testing.

The issue is that the code is developed assuming that the workdir is fixed, but during local testing this assumption is violated.