### PR TITLE
fix(storage): missing validation for s3 bucket names

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -2,8 +2,10 @@ package storage
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -64,6 +66,11 @@ func (s *S3) Tune(options map[string]interface{}) error {
 }
 
 func (s *S3) Get(name string) ([]byte, []byte, error) {
+	bucketName, err := nameToBucket(name)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	client := s3.New(
 		session.Must(session.NewSession()),
 		s.config,
@@ -71,7 +78,7 @@ func (s *S3) Get(name string) ([]byte, []byte, error) {
 
 	crtData := bytes.NewBuffer(nil)
 	if data, err := client.GetObject(&s3.GetObjectInput{
-		Bucket: nameToBucket(name),
+		Bucket: bucketName,
 		Key:    &s3CrtName,
 	}); err != nil {
 		return nil, nil, err
@@ -84,7 +91,7 @@ func (s *S3) Get(name string) ([]byte, []byte, error) {
 
 	keyData := bytes.NewBuffer(nil)
 	if data, err := client.GetObject(&s3.GetObjectInput{
-		Bucket: nameToBucket(name),
+		Bucket: bucketName,
 		Key:    &s3KeyName,
 	}); err != nil {
 		return nil, nil, err
@@ -99,19 +106,24 @@ func (s *S3) Get(name string) ([]byte, []byte, error) {
 }
 
 func (s *S3) Put(name string, crtData, keyData []byte) error {
+	bucketName, err := nameToBucket(name)
+	if err != nil {
+		return err
+	}
+
 	client := s3.New(
 		session.Must(session.NewSession()),
 		s.config,
 	)
 
-	if _, err := client.CreateBucket(&s3.CreateBucketInput{Bucket: nameToBucket(name)}); err != nil &&
+	if _, err := client.CreateBucket(&s3.CreateBucketInput{Bucket: bucketName}); err != nil &&
 		strings.HasPrefix(err.Error(), s3.ErrCodeBucketAlreadyExists) &&
 		strings.HasPrefix(err.Error(), s3.ErrCodeBucketAlreadyOwnedByYou) {
 		return err
 	}
 
 	if _, err := client.PutObject(&s3.PutObjectInput{
-		Bucket: nameToBucket(name),
+		Bucket: bucketName,
 		Key:    &s3CrtName,
 		Body:   bytes.NewReader(crtData),
 	}); err != nil {
@@ -119,7 +131,7 @@ func (s *S3) Put(name string, crtData, keyData []byte) error {
 	}
 
 	if _, err := client.PutObject(&s3.PutObjectInput{
-		Bucket: nameToBucket(name),
+		Bucket: bucketName,
 		Key:    &s3KeyName,
 		Body:   bytes.NewReader(keyData),
 	}); err != nil {
@@ -130,6 +142,11 @@ func (s *S3) Put(name string, crtData, keyData []byte) error {
 }
 
 func (s *S3) Del(name string) error {
+	bucketName, err := nameToBucket(name)
+	if err != nil {
+		return err
+	}
+
 	client := s3.New(
 		session.Must(session.NewSession()),
 		s.config,
@@ -138,13 +155,13 @@ func (s *S3) Del(name string) error {
 	if err := s3manager.NewBatchDeleteWithClient(client).Delete(
 		aws.BackgroundContext(),
 		s3manager.NewDeleteListIterator(client, &s3.ListObjectsInput{
-			Bucket: nameToBucket(name),
+			Bucket: bucketName,
 		})); err != nil {
 		return err
 	}
 
 	if _, err := client.DeleteBucket(&s3.DeleteBucketInput{
-		Bucket: nameToBucket(name),
+		Bucket: bucketName,
 	}); err != nil {
 		return err
 	}
@@ -165,8 +182,7 @@ func (s *S3) Find(filters ...string) ([][]byte, error) {
 
 	results := [][]byte{}
 	for _, bucket := range buckets.Buckets {
-		if !(pki.IsValidCN(bucketToName(bucket.Name)) &&
-			util.RegexesMatch(bucketToName(bucket.Name), filters...)) {
+		if !matchFilters(bucket.Name, filters) {
 			continue
 		}
 
@@ -188,11 +204,87 @@ func (s *S3) Config() map[string]string {
 	}
 }
 
-func nameToBucket(name string) *string {
-	bucket := strings.ReplaceAll(name, ".", "-")
-	return &bucket
+func nameToBucket(name string) (*string, error) {
+	bucket := strings.TrimPrefix(name, "*.")
+	if !validateBucketName(bucket) {
+		return nil, errors.New("unsupported CN (protocol violation)")
+	}
+
+	// Buckets used with Amazon S3 Transfer Acceleration can't have dots (.) in their names
+	bucket = strings.ReplaceAll(bucket, ".", "-")
+	return &bucket, nil
 }
 
-func bucketToName(bucket *string) string {
-	return strings.ReplaceAll(*bucket, "-", ".")
+func matchFilters(bucket *string, filters []string) bool {
+	name := strings.ReplaceAll(*bucket, "-", ".")
+	wildcardName := "*." + name
+
+	return pki.IsValidCN(name) && util.RegexesMatch(name, filters...) ||
+		pki.IsValidCN(wildcardName) && util.RegexesMatch(wildcardName, filters...)
+}
+
+func validateBucketName(name string) bool {
+
+	// Bucket names cannot be formatted as IP addresses
+	if net.ParseIP(name) != nil {
+		return false
+	}
+
+	// Bucket names must not start with the prefix xn--
+	if strings.HasPrefix(name, "xn--") {
+		return false
+	}
+
+	// Bucket names must not start with the prefix sthree-
+	if strings.HasPrefix(name, "sthree-") {
+		return false
+	}
+
+	// Bucket names must not end with the suffix -s3alias
+	if strings.HasSuffix(name, "-s3alias") {
+		return false
+	}
+
+	// Bucket names must not end with the suffix --ol-s3
+	if strings.HasSuffix(name, "--ol-s3") {
+		return false
+	}
+
+	// Bucket names can be between 3 and 63 characters long
+	if len(name) < 3 || len(name) > 63 {
+		return false
+	}
+
+	// Bucket names must not contain uppercase characters
+	if name != strings.ToLower(name) {
+		return false
+	}
+
+	// Bucket names must not contain underscores
+	if strings.Contains(name, "_") {
+		return false
+	}
+
+	// Bucket names must be a series of one or more labels
+	for _, label := range strings.Split(name, ".") {
+
+		// Adjacent labels are separated by a single period (.)
+		if len(label) < 1 {
+			return false
+		}
+
+		// Each label can contain lowercase letters, numbers, and hyphens
+		for _, char := range label {
+			if !('a' <= char && char <= 'z') && !('0' <= char && char <= '9') && char != '-' {
+				return false
+			}
+		}
+
+		// Each label must start and end with a lowercase letter or a number
+		if label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+	}
+
+	return true
 }

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -1,0 +1,203 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/matryer/is"
+)
+
+func TestS3_Tune(t *testing.T) {
+	t.Parallel()
+
+	s := &S3{}
+	options := map[string]interface{}{
+		"endpoint": "https://s3.amazonaws.com",
+		"access":   "access_key",
+		"secret":   "secret_key",
+		"region":   "us-west-2",
+	}
+
+	err := s.Tune(options)
+	test := is.New(t)
+	test.NoErr(err)
+
+	expectedConfig := aws.NewConfig().
+		WithEndpoint("https://s3.amazonaws.com").
+		WithDisableSSL(false).
+		WithRegion("us-west-2").
+		WithS3ForcePathStyle(true).
+		WithCredentials(credentials.NewStaticCredentials(
+			"access_key",
+			"secret_key",
+			"",
+		))
+
+	test.Equal(s.config.Endpoint, expectedConfig.Endpoint)
+	test.Equal(s.config.DisableSSL, expectedConfig.DisableSSL)
+	test.Equal(s.config.Region, expectedConfig.Region)
+	test.Equal(s.config.S3ForcePathStyle, expectedConfig.S3ForcePathStyle)
+}
+
+func TestS3_Tune_MissingEndpoint(t *testing.T) {
+	t.Parallel()
+
+	s := &S3{}
+	options := map[string]interface{}{
+		"access": "access_key",
+		"secret": "secret_key",
+		"region": "us-west-2",
+	}
+
+	err := s.Tune(options)
+	test := is.New(t)
+	test.Equal(err, fmt.Errorf("provider %s: endpoint not defined", s.ID()))
+}
+
+func TestS3_Tune_MissingAccess(t *testing.T) {
+	t.Parallel()
+
+	s := &S3{}
+	options := map[string]interface{}{
+		"endpoint": "https://s3.amazonaws.com",
+		"secret":   "secret_key",
+		"region":   "us-west-2",
+	}
+
+	err := s.Tune(options)
+	test := is.New(t)
+	test.Equal(err, fmt.Errorf("provider %s: access not defined", s.ID()))
+}
+
+func TestS3_Tune_MissingSecret(t *testing.T) {
+	t.Parallel()
+
+	s := &S3{}
+	options := map[string]interface{}{
+		"endpoint": "https://s3.amazonaws.com",
+		"access":   "access_key",
+		"region":   "us-west-2",
+	}
+
+	err := s.Tune(options)
+	test := is.New(t)
+	test.Equal(err, fmt.Errorf("provider %s: secret not defined", s.ID()))
+}
+
+func TestS3_Tune_MissingRegion(t *testing.T) {
+	t.Parallel()
+
+	s := &S3{}
+	options := map[string]interface{}{
+		"endpoint": "https://s3.amazonaws.com",
+		"access":   "access_key",
+		"secret":   "secret_key",
+	}
+
+	err := s.Tune(options)
+	test := is.New(t)
+	test.Equal(err, fmt.Errorf("provider %s: region not defined", s.ID()))
+}
+
+func TestS3_Config(t *testing.T) {
+	t.Parallel()
+
+	s := &S3{
+		config: &aws.Config{
+			Endpoint: aws.String("https://s3.amazonaws.com"),
+			Region:   aws.String("us-west-2"),
+		},
+	}
+
+	expected := map[string]string{
+		"Endpoint": "https://s3.amazonaws.com",
+		"Region":   "us-west-2",
+	}
+
+	result := s.Config()
+
+	test := is.New(t)
+	test.Equal(result, expected)
+}
+
+func Test_nameToBucket(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{
+			name:    "127.0.0.1",
+			wantErr: true,
+		},
+		{
+			name:    "::1",
+			wantErr: true,
+		},
+		{
+			name:    "xn--wgv71a119e.idn.icann.org",
+			wantErr: true,
+		},
+		{
+			name:    "sthree-testprefix.it",
+			wantErr: true,
+		},
+		{
+			name:    "testsuffix.-s3alias",
+			wantErr: true,
+		},
+		{
+			name:    "testsuffix.--ol-s3",
+			wantErr: true,
+		},
+		{
+			name:    "underscore_test.it",
+			wantErr: true,
+		},
+		{
+			name:    ".dot-start.com",
+			wantErr: true,
+		},
+		{
+			name:    "example.com",
+			wantErr: false,
+		},
+		{
+			name:    "example.com.",
+			wantErr: true,
+		},
+		{
+			name:    "*.example.com",
+			wantErr: false,
+		},
+		{
+			name:    "*.example.com.",
+			wantErr: true,
+		},
+		{
+			name:    "0x20eNc0d1Ng.com.",
+			wantErr: true,
+		},
+		{
+			name:    "-hypen-start.it",
+			wantErr: true,
+		},
+		{
+			name:    "hypen-end-.it",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := nameToBucket(tt.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("nameToBucket(%s) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
We are ***blindly forwarding every CN to S3*** as a bucket name. This is the main defect that ultimately leads to https://github.com/immobiliare/inca/issues/128.

I have been considering whether it is wrong to encode, decode, and search for certificates names on S3 without relying on a database. And certainly, the naming requirements for S3 buckets and zones diverge.

This MR adds validation for s3 bucket names.

Additionally, we are now special ***casing wildcards in CNs***. 
Best practice would suggest having Apex in the `Common Name` and Apex plus the wildcard in the `Subject Alternative Name`. Nonetheless, it is certainly advisable to support this use case.

To handle it, I introduced wildcard stripping: wildcards are flattened along with the zone itself. Closes #128
