### PR TITLE
Support the download of a certificate in pfx format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/matryer/is v1.4.1
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.9.1
+	software.sslmate.com/src/go-pkcs12 v0.5.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2567,3 +2567,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.7.0/go.mod h1:dDy58f92j70zLsuZVuUX5Wp9vt
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
+software.sslmate.com/src/go-pkcs12 v0.5.0 h1:EC6R394xgENTpZ4RltKydeDUjtlM5drOYIG9c6TVj2M=
+software.sslmate.com/src/go-pkcs12 v0.5.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/server/inca.go
+++ b/server/inca.go
@@ -109,6 +109,7 @@ func Spinup(path string) (*Inca, error) {
 	incaWeb.Get("/import", inca.handlerWebImportView)
 	incaWeb.Post("/import", inca.handlerWebImport)
 	incaWeb.Get("/:name", inca.handlerWebView)
+	incaWeb.Get("/:name/pfx", inca.handlerWebDownloadPfx)
 	incaWeb.Get("/:name/download", inca.handlerWebDownload)
 	incaWeb.Post("/:name/delete", inca.handlerWebDelete)
 	inca.Get("/enum", inca.handlerEnum)

--- a/server/views/view.html.j2
+++ b/server/views/view.html.j2
@@ -60,5 +60,8 @@
 <form method="GET" action="/web/{{ crt.CN }}/download">
     <button>Download</button>
 </form>
+<form method="GET" action="/web/{{ crt.CN }}/pfx">
+    <button>Download PFX</button>
+</form>
 {% endif %}
 {% endblock %}

--- a/server/web_download.go
+++ b/server/web_download.go
@@ -3,9 +3,13 @@ package server
 import (
 	"archive/zip"
 	"bytes"
+	"crypto/x509"
+	"encoding/pem"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/immobiliare/inca/util"
 	"github.com/rs/zerolog/log"
+	"software.sslmate.com/src/go-pkcs12"
 )
 
 func (inca *Inca) handlerWebDownload(c *fiber.Ctx) error {
@@ -27,6 +31,74 @@ func (inca *Inca) handlerWebDownload(c *fiber.Ctx) error {
 	for key, value := range map[string][]byte{
 		name + ".crt": crt,
 		name + ".key": key,
+	} {
+		file, err := zip.Create(key)
+		if err != nil {
+			_ = c.Bind(fiber.Map{"error": "Unable to create ZIP archive entry"})
+			log.Error().Err(err).Msg("unable to create ZIP archive entry")
+			return inca.handlerWebView(c)
+		}
+
+		if _, err := file.Write(value); err != nil {
+			_ = c.Bind(fiber.Map{"error": "Unable to add content to ZIP archive entry"})
+			log.Error().Err(err).Msg("unable to add content to ZIP archive entry")
+			return inca.handlerWebView(c)
+		}
+	}
+
+	if err := zip.Close(); err != nil {
+		_ = c.Bind(fiber.Map{"error": "Unable to close ZIP archive"})
+		log.Error().Err(err).Msg("unable to close ZIP archive")
+		return inca.handlerWebView(c)
+	}
+
+	c.Response().Header.Add(fiber.HeaderContentDisposition, `attachment; filename="`+name+`.zip"`)
+	return c.SendStream(out, len(out.Bytes()))
+}
+
+func (inca *Inca) handlerWebDownloadPfx(c *fiber.Ctx) error {
+	name := c.Params("name")
+
+	if !inca.authorizedTarget(name, c) {
+		_ = c.Bind(fiber.Map{"error": "Unauthorized to download the certificate"})
+		return inca.handlerWebIndex(c)
+	}
+
+	crt, key, err := (*inca.Storage).Get(name)
+	if err != nil {
+		_ = c.Bind(fiber.Map{"error": "Certificate not found"})
+		return inca.handlerWebIndex(c)
+	}
+
+	certBlock, _ := pem.Decode([]byte(crt))
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		_ = c.Bind(fiber.Map{"error": "Unable to parse certificate"})
+		log.Error().Err(err).Msg("unable to parse certificate")
+		return inca.handlerWebView(c)
+	}
+
+	keyBlock, _ := pem.Decode([]byte(key))
+	privateKey, err := x509.ParsePKCS8PrivateKey(keyBlock.Bytes)
+	if err != nil {
+		_ = c.Bind(fiber.Map{"error": "Unable to parse private key"})
+		log.Error().Err(err).Msg("unable to parse private key")
+		return inca.handlerWebView(c)
+	}
+
+	password := util.GenerateRandomString(256)
+	pfxData, err := pkcs12.Modern.Encode(privateKey, cert, nil, password)
+	if err != nil {
+		_ = c.Bind(fiber.Map{"error": "Unable to create PFX"})
+		log.Error().Err(err).Msg("unable to create PFX")
+		return inca.handlerWebView(c)
+	}
+
+	out := new(bytes.Buffer)
+	zip := zip.NewWriter(out)
+	for key, value := range map[string][]byte{
+		name + ".pfx": pfxData,
+		name + ".txt": []byte(password),
 	} {
 		file, err := zip.Create(key)
 		if err != nil {

--- a/server/web_download.go
+++ b/server/web_download.go
@@ -84,6 +84,11 @@ func (inca *Inca) handlerWebDownloadPfx(c *fiber.Ctx) error {
 	}
 
 	keyBlock, _ := pem.Decode([]byte(key))
+	if keyBlock == nil {
+		_ = c.Bind(fiber.Map{"error": "Invalid PEM data for private key"})
+		log.Error().Msg("invalid PEM data for private key")
+		return inca.handlerWebView(c)
+	}
 	privateKey, err := x509.ParsePKCS8PrivateKey(keyBlock.Bytes)
 	if err != nil {
 		_ = c.Bind(fiber.Map{"error": "Unable to parse private key"})

--- a/server/web_download.go
+++ b/server/web_download.go
@@ -71,6 +71,11 @@ func (inca *Inca) handlerWebDownloadPfx(c *fiber.Ctx) error {
 	}
 
 	certBlock, _ := pem.Decode([]byte(crt))
+	if certBlock == nil {
+		_ = c.Bind(fiber.Map{"error": "Invalid PEM content for certificate"})
+		log.Error().Msg("invalid PEM content for certificate")
+		return inca.handlerWebView(c)
+	}
 	cert, err := x509.ParseCertificate(certBlock.Bytes)
 	if err != nil {
 		_ = c.Bind(fiber.Map{"error": "Unable to parse certificate"})

--- a/server/web_download_test.go
+++ b/server/web_download_test.go
@@ -47,3 +47,16 @@ func TestServerWebDownload(t *testing.T) {
 	test.NoErr(err)
 	test.Equal(response.StatusCode, fiber.StatusOK)
 }
+
+func TestServerWebDownloadPfx(t *testing.T) {
+	var (
+		app  = testApp(t)
+		test = is.New(t)
+	)
+
+	response, err := app.Test(
+		httptest.NewRequest("GET", fmt.Sprintf("/web/%s/pfx", testingCADomain), nil),
+	)
+	test.NoErr(err)
+	test.Equal(response.StatusCode, fiber.StatusOK)
+}

--- a/server/web_download_test.go
+++ b/server/web_download_test.go
@@ -55,8 +55,24 @@ func TestServerWebDownloadPfx(t *testing.T) {
 	)
 
 	response, err := app.Test(
+		httptest.NewRequest("GET", "/"+testingCADomain+"?algo="+testingCAAlgorithm, nil),
+	)
+	test.NoErr(err)
+	test.Equal(response.StatusCode, fiber.StatusOK)
+
+	response, err = app.Test(
 		httptest.NewRequest("GET", fmt.Sprintf("/web/%s/pfx", testingCADomain), nil),
 	)
 	test.NoErr(err)
 	test.Equal(response.StatusCode, fiber.StatusOK)
+
+	body, err := io.ReadAll(response.Body)
+	test.NoErr(err)
+	defer func() {
+		if err := response.Body.Close(); err != nil {
+			t.Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	test.True(len(body) > 0)
 }

--- a/util/string.go
+++ b/util/string.go
@@ -1,6 +1,28 @@
 package util
 
-import "regexp"
+import (
+	"crypto/rand"
+	"math/big"
+	mrand "math/rand/v2"
+	"regexp"
+)
+
+const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*"
+
+func GenerateRandomString(length int) string {
+	result := make([]byte, length)
+	charsetLength := big.NewInt(int64(len(charset)))
+
+	for i := 0; i < length; i++ {
+		randomIndex, err := rand.Int(rand.Reader, charsetLength)
+		if err != nil {
+			randomIndex = big.NewInt(int64(mrand.IntN(len(charset))))
+		}
+		result[i] = charset[randomIndex.Int64()]
+	}
+
+	return string(result)
+}
 
 func RegexesMatch(payload string, regexes ...string) bool {
 	match := true

--- a/util/string_test.go
+++ b/util/string_test.go
@@ -43,3 +43,39 @@ func TestUtilStringRegexesNotAnyMatch(t *testing.T) {
 
 	is.New(t).True(!RegexesAnyMatch(testingString, "^$"))
 }
+
+func TestGenerateRandomString_Length(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+
+	for _, l := range []int{0, 1, 5, 10, 50, 100} {
+		s := GenerateRandomString(l)
+		is.Equal(len(s), l)
+	}
+}
+
+func TestGenerateRandomString_Charset(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+
+	s := GenerateRandomString(1000)
+	for _, c := range s {
+		found := false
+		for _, allowed := range charset {
+			if c == allowed {
+				found = true
+				break
+			}
+		}
+		is.True(found)
+	}
+}
+
+func TestGenerateRandomString_Uniqueness(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+
+	s1 := GenerateRandomString(32)
+	s2 := GenerateRandomString(32)
+	is.True(s1 != s2)
+}


### PR DESCRIPTION
This PR adds an option to download a pfx certificate from the web UI.

A **_Personal Information Exchange_**, is password protected file certificate commonly used for code signing your application. It derives from the PKCS 12 archive file format certificate, and it stores multiple cryptographic objects within a single file.

The PFX file is self-contained: everything needed (certificate + private key + chain) is bundled into a single file. This makes it convenient to install, especially on mobile devices, embedded systems, network appliances, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to download certificates in PFX (PKCS#12) format from the web interface. The downloaded file includes a randomly generated password and is delivered as a ZIP archive containing both the PFX file and the password.
  - Introduced a "Download PFX" button on the certificate view page for eligible certificates.

- **Bug Fixes**
  - Improved error handling during the PFX download process.

- **Tests**
  - Added tests to verify the PFX download endpoint and the random string generation utility.

- **Chores**
  - Updated dependencies to support PKCS#12 encoding.
  - Added a utility for generating cryptographically secure random strings used for password creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->